### PR TITLE
feat: discover A2A agents from ORD endpoints

### DIFF
--- a/e2e/fixtures/playground.ts
+++ b/e2e/fixtures/playground.ts
@@ -12,6 +12,9 @@ export class PlaygroundPage {
   readonly addAgentUrl: Locator;
   readonly addAgentSubmit: Locator;
   readonly addAgentCancel: Locator;
+  readonly discoverOrdBtn: Locator;
+  readonly ordUrlInput: Locator;
+  readonly discoverOrdSubmit: Locator;
 
   // Editor
   readonly editorPanel: Locator;
@@ -61,6 +64,9 @@ export class PlaygroundPage {
     this.addAgentUrl = page.locator("[data-testid='add-agent-url']");
     this.addAgentSubmit = page.locator("[data-testid='add-agent-submit']");
     this.addAgentCancel = page.locator("[data-testid='add-agent-cancel']");
+    this.discoverOrdBtn = page.locator("[data-testid='discover-ord-btn']");
+    this.ordUrlInput = page.locator("[data-testid='ord-url-input']");
+    this.discoverOrdSubmit = page.locator("[data-testid='discover-ord-submit']");
 
     // Editor
     this.editorPanel = page.locator("[data-testid='editor-panel']");

--- a/e2e/tests/ord-discovery.spec.ts
+++ b/e2e/tests/ord-discovery.spec.ts
@@ -5,7 +5,7 @@ const ORD_HOST = "https://ord-host.example.com";
 
 const ORD_CONFIG = {
   openResourceDiscoveryV1: {
-    documents: [{ url: "/open-resource-discovery/v1/documents/1" }],
+    documents: [{ url: "/ord/v1/documents/1" }],
   },
 };
 
@@ -43,7 +43,7 @@ async function mockOrdChain(page: Page) {
       body: JSON.stringify(ORD_CONFIG),
     }),
   );
-  await page.route(`${ORD_HOST}/open-resource-discovery/v1/documents/1`, (route) =>
+  await page.route(`${ORD_HOST}/ord/v1/documents/1`, (route) =>
     route.fulfill({
       status: 200,
       contentType: "application/json",

--- a/e2e/tests/ord-discovery.spec.ts
+++ b/e2e/tests/ord-discovery.spec.ts
@@ -1,0 +1,187 @@
+import { type Page } from "@playwright/test";
+import { test, expect } from "../fixtures/playground";
+
+const ORD_HOST = "https://ord-host.example.com";
+
+const ORD_CONFIG = {
+  openResourceDiscoveryV1: {
+    documents: [{ url: "/open-resource-discovery/v1/documents/1" }],
+  },
+};
+
+const ORD_DOC = {
+  agents: [
+    {
+      ordId: "ns:agent:my-agent:v1",
+      exposedApiResources: [{ ordId: "ns:api:my-api:v1" }],
+    },
+  ],
+  apiResources: [
+    {
+      ordId: "ns:api:my-api:v1",
+      title: "My API",
+      apiProtocol: "a2a",
+      resourceDefinitions: [{ type: "a2a-agent-card", url: "/api/agents/my-agent/agent.json" }],
+    },
+  ],
+};
+
+const AGENT_CARD = {
+  name: "Discovered ORD Agent",
+  description: "Test ORD agent",
+  url: ORD_HOST,
+  skills: [],
+};
+
+const AGENT_ID = "ord-ns:api:my-api:v1";
+
+async function mockOrdChain(page: Page) {
+  await page.route(`${ORD_HOST}/.well-known/open-resource-discovery`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(ORD_CONFIG),
+    }),
+  );
+  await page.route(`${ORD_HOST}/open-resource-discovery/v1/documents/1`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(ORD_DOC),
+    }),
+  );
+  await page.route(`${ORD_HOST}/api/agents/my-agent/agent.json`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(AGENT_CARD),
+    }),
+  );
+}
+
+test.describe("ORD Discovery", () => {
+  test.beforeEach(async ({ playground }) => {
+    await playground.goto();
+  });
+
+  test("should open and close the Discover ORD form", async ({ playground }) => {
+    await playground.discoverOrdBtn.click();
+    await expect(playground.ordUrlInput).toBeVisible();
+    await expect(playground.discoverOrdSubmit).toBeVisible();
+    // Toggle closed
+    await playground.discoverOrdBtn.click();
+    await expect(playground.ordUrlInput).toBeHidden();
+  });
+
+  test("should close Add form when Discover form is opened, and vice versa", async ({ playground }) => {
+    // Open Add form
+    await playground.addAgentBtn.click();
+    await expect(playground.addAgentUrl).toBeVisible();
+    // Open Discover form — Add form should close
+    await playground.discoverOrdBtn.click();
+    await expect(playground.ordUrlInput).toBeVisible();
+    await expect(playground.addAgentUrl).toBeHidden();
+    // Open Add form again — Discover form should close
+    await playground.addAgentBtn.click();
+    await expect(playground.addAgentUrl).toBeVisible();
+    await expect(playground.ordUrlInput).toBeHidden();
+  });
+
+  test("should keep Discover submit disabled when input is empty", async ({ playground }) => {
+    await playground.discoverOrdBtn.click();
+    await expect(playground.discoverOrdSubmit).toBeDisabled();
+    await playground.ordUrlInput.fill(ORD_HOST);
+    await expect(playground.discoverOrdSubmit).toBeEnabled();
+  });
+
+  test("should discover and display ORD agent card", async ({ playground, page }) => {
+    await mockOrdChain(page);
+    await playground.discoverOrdBtn.click();
+    await playground.ordUrlInput.fill(ORD_HOST);
+    await playground.discoverOrdSubmit.click();
+
+    await expect(playground.agentCard(AGENT_ID)).toBeVisible({ timeout: 10000 });
+    await expect(playground.agentCard(AGENT_ID)).toContainText("Discovered ORD Agent");
+  });
+
+  test("should show success message after discovery", async ({ playground, page }) => {
+    await mockOrdChain(page);
+    await playground.discoverOrdBtn.click();
+    await playground.ordUrlInput.fill(ORD_HOST);
+    await playground.discoverOrdSubmit.click();
+
+    await expect(playground.agentCard(AGENT_ID)).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText("Added 1 agent")).toBeVisible();
+  });
+
+  test("should show 'No new agents found' when re-discovering same URL", async ({ playground, page }) => {
+    await mockOrdChain(page);
+    await playground.discoverOrdBtn.click();
+    await playground.ordUrlInput.fill(ORD_HOST);
+    await playground.discoverOrdSubmit.click();
+
+    // Wait for first discovery to complete
+    await expect(playground.agentCard(AGENT_ID)).toBeVisible({ timeout: 10000 });
+
+    // Discover again — same URL still in the input
+    await playground.discoverOrdSubmit.click();
+    await expect(page.getByText("No new agents found")).toBeVisible({ timeout: 10000 });
+  });
+
+  test("should show error when ORD config endpoint returns 404", async ({ playground, page }) => {
+    await page.route(`${ORD_HOST}/.well-known/open-resource-discovery`, (route) =>
+      route.fulfill({ status: 404, statusText: "Not Found" }),
+    );
+
+    await playground.discoverOrdBtn.click();
+    await playground.ordUrlInput.fill(ORD_HOST);
+    await playground.discoverOrdSubmit.click();
+
+    await expect(page.getByText(/ORD config fetch failed/)).toBeVisible({ timeout: 10000 });
+  });
+
+  test("should remove ORD agent on hover and click X", async ({ playground, page }) => {
+    await mockOrdChain(page);
+    await playground.discoverOrdBtn.click();
+    await playground.ordUrlInput.fill(ORD_HOST);
+    await playground.discoverOrdSubmit.click();
+
+    const card = playground.agentCard(AGENT_ID);
+    await expect(card).toBeVisible({ timeout: 10000 });
+
+    await card.hover();
+    await card.locator("button").click();
+
+    await expect(card).toBeHidden();
+  });
+
+  test("should trigger discovery on Enter key in URL input", async ({ playground, page }) => {
+    await mockOrdChain(page);
+    await playground.discoverOrdBtn.click();
+    await playground.ordUrlInput.fill(ORD_HOST);
+    await playground.ordUrlInput.press("Enter");
+
+    await expect(playground.agentCard(AGENT_ID)).toBeVisible({ timeout: 10000 });
+  });
+
+  test("should show 'ORD Agents' section header after discovery", async ({ playground, page }) => {
+    await mockOrdChain(page);
+    await playground.discoverOrdBtn.click();
+    await playground.ordUrlInput.fill(ORD_HOST);
+    await playground.discoverOrdSubmit.click();
+
+    await expect(playground.agentCard(AGENT_ID)).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText("ORD Agents")).toBeVisible();
+  });
+
+  test("should keep Discover form open after successful discovery", async ({ playground, page }) => {
+    await mockOrdChain(page);
+    await playground.discoverOrdBtn.click();
+    await playground.ordUrlInput.fill(ORD_HOST);
+    await playground.discoverOrdSubmit.click();
+
+    await expect(playground.agentCard(AGENT_ID)).toBeVisible({ timeout: 10000 });
+    // Unlike the Add form, the ORD form stays open to allow re-discovery
+    await expect(playground.ordUrlInput).toBeVisible();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
+        "@open-resource-discovery/specification": "^1.14.5",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -1508,6 +1509,16 @@
         "monaco-editor": ">= 0.25.0 < 1",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@open-resource-discovery/specification": {
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/@open-resource-discovery/specification/-/specification-1.14.5.tgz",
+      "integrity": "sha512-70ftTQCTOV/poTwCB7as4/Nkw0W825OI1MEs5jt5PVD/RwN44HihCraAy24I7jrlw8n91dPT51cgKyWBWJ8mLw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0",
+        "npm": ">=11.0.0"
       }
     },
     "node_modules/@playwright/test": {

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
   },
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",
+    "@open-resource-discovery/specification": "^1.14.5",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/src/lib/components/settings/PredefinedAgents.tsx
+++ b/src/lib/components/settings/PredefinedAgents.tsx
@@ -10,7 +10,7 @@ import { selectPredefinedAgent } from "@lib/utils/agent-selection";
 import { detectProtocolVersion, normalizeAgentCard } from "@lib/utils/a2a-protocol";
 import { buildAddHeaders, mapAddAuth, buildPredefinedConnHeaders } from "@lib/utils/predefined-auth";
 import type { AddAuthType } from "@lib/utils/predefined-auth";
-import { Search, Plus, X, Loader2 } from "lucide-react";
+import { Search, Plus, X, Loader2, Globe } from "lucide-react";
 import type { PredefinedAgent } from "@lib/types/connection";
 
 function parseAgentUrl(input: string): { normalizedUrl: string; fetchUrl: string } {
@@ -38,7 +38,7 @@ function parseAgentUrl(input: string): { normalizedUrl: string; fetchUrl: string
 }
 
 export function PredefinedAgents() {
-  const { agents, selectedId, loadDefaults, deselect, addCustomAgent, removeAgent } =
+  const { agents, selectedId, loadDefaults, deselect, addCustomAgent, removeAgent, loadFromOrd } =
     usePredefinedAgentsStore();
 
   const [search, setSearch] = useState("");
@@ -52,15 +52,23 @@ export function PredefinedAgents() {
   const [addToken, setAddToken] = useState("");
   const [addApiKey, setAddApiKey] = useState("");
 
+  const [showOrdForm, setShowOrdForm] = useState(false);
+  const [ordUrl, setOrdUrl] = useState("");
+  const [isDiscovering, setIsDiscovering] = useState(false);
+  const [discoverError, setDiscoverError] = useState("");
+  const [discoverMessage, setDiscoverMessage] = useState("");
+
   useEffect(() => {
     loadDefaults();
   }, [loadDefaults]);
 
-  // Separate custom and predefined agents
   const customAgents = useMemo(() => agents.filter((a) => a.id.startsWith("custom-")), [agents]);
-  const predefinedAgents = useMemo(() => agents.filter((a) => !a.id.startsWith("custom-")), [agents]);
+  const ordAgents = useMemo(() => agents.filter((a) => a.id.startsWith("ord-")), [agents]);
+  const predefinedAgents = useMemo(
+    () => agents.filter((a) => !a.id.startsWith("custom-") && !a.id.startsWith("ord-")),
+    [agents],
+  );
 
-  // Filter agents by search (name, description, tags)
   const filterAgents = (agentList: PredefinedAgent[]) => {
     if (!search) return agentList;
     const query = search.toLowerCase();
@@ -73,6 +81,7 @@ export function PredefinedAgents() {
   };
 
   const filteredCustom = filterAgents(customAgents);
+  const filteredOrd = filterAgents(ordAgents);
   const filteredPredefined = filterAgents(predefinedAgents);
   const isValidNewAgentUrl = (() => {
     if (!newAgentUrl.trim()) return false;
@@ -161,6 +170,21 @@ export function PredefinedAgents() {
     }
   };
 
+  const handleDiscover = async () => {
+    if (!ordUrl.trim()) return;
+    setIsDiscovering(true);
+    setDiscoverError("");
+    setDiscoverMessage("");
+    try {
+      const added = await loadFromOrd(ordUrl.trim());
+      setDiscoverMessage(added === 0 ? "No new agents found" : `Added ${added} agent${added !== 1 ? "s" : ""}`);
+    } catch (err) {
+      setDiscoverError(err instanceof Error ? err.message : "Discovery failed");
+    } finally {
+      setIsDiscovering(false);
+    }
+  };
+
   const renderAgentCard = (agent: PredefinedAgent, isCustom: boolean) => (
     <div
       key={agent.id}
@@ -211,125 +235,170 @@ export function PredefinedAgents() {
       <div className="sticky top-0 z-10 bg-sidebar pt-8 pb-3 space-y-3">
         <div className="flex items-center justify-between">
           <span className="text-sm font-medium">Agents</span>
-          <Button variant="ghost" size="sm" className="h-7 gap-1" onClick={() => setShowAddForm(!showAddForm)} data-testid="add-agent-btn">
-            <Plus className="h-3.5 w-3.5" />
-            Add
-          </Button>
-        </div>
-
-        {/* Add agent form */}
-        {showAddForm && (
-        <div className="rounded-lg border p-3 space-y-2 bg-muted/50">
-          <Input
-            placeholder="Enter agent URL..."
-            data-testid="add-agent-url"
-            value={newAgentUrl}
-            onChange={(e) => {
-              setNewAgentUrl(e.target.value);
-              if (addError) {
-                setAddError("");
-              }
-            }}
-            className="h-8 text-sm"
-            type="url"
-            inputMode="url"
-            autoComplete="url"
-            onKeyDown={(e) => e.key === "Enter" && handleAddAgent()}
-          />
-          {addError && <p className="text-xs text-destructive">{addError}</p>}
-          {!addError && newAgentUrl.trim() && !isValidNewAgentUrl && (
-            <p className="text-xs text-destructive">Please enter a valid absolute http:// or https:// URL.</p>
-          )}
-
-          {/* Auth for secured agent card endpoints */}
-          <Select value={addAuthType} onValueChange={(v) => setAddAuthType(v as AddAuthType)}>
-            <SelectTrigger className="h-8 text-xs">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="none">No Authentication</SelectItem>
-              <SelectItem value="basic">Basic Auth</SelectItem>
-              <SelectItem value="bearer">Bearer Token</SelectItem>
-              <SelectItem value="apiKey">API Key</SelectItem>
-            </SelectContent>
-          </Select>
-
-          {addAuthType === "basic" && (
-            <div className="space-y-2">
-              <Input
-                placeholder="Username"
-                value={addUsername}
-                onChange={(e) => setAddUsername(e.target.value)}
-                className="h-8 text-sm"
-                autoComplete="off"
-              />
-              <PasswordInput
-                placeholder="Password"
-                value={addPassword}
-                onChange={(e) => setAddPassword(e.target.value)}
-                className="h-8 text-sm"
-                autoComplete="off"
-              />
-            </div>
-          )}
-
-          {addAuthType === "bearer" && (
-            <PasswordInput
-              placeholder="Bearer Token"
-              value={addToken}
-              onChange={(e) => setAddToken(e.target.value)}
-              className="h-8 text-sm"
-              autoComplete="off"
-            />
-          )}
-
-          {addAuthType === "apiKey" && (
-            <PasswordInput
-              placeholder="API Key"
-              value={addApiKey}
-              onChange={(e) => setAddApiKey(e.target.value)}
-              className="h-8 text-sm"
-              autoComplete="off"
-            />
-          )}
-
-          <div className="flex flex-wrap justify-end gap-2">
+          <div className="flex items-center gap-1">
             <Button
               variant="ghost"
               size="sm"
-              onClick={() => {
-                setShowAddForm(false);
-                setNewAgentUrl("");
-                setAddError("");
-              }}
-              data-testid="add-agent-cancel">
-              Cancel
+              className="h-7 gap-1"
+              onClick={() => { setShowOrdForm(!showOrdForm); setShowAddForm(false); }}
+              data-testid="discover-ord-btn">
+              <Globe className="h-3.5 w-3.5" />
+              Discover
             </Button>
-            <Button size="sm" onClick={handleAddAgent} disabled={isAdding || !isValidNewAgentUrl} data-testid="add-agent-submit">
-              {isAdding ? (
-                <>
-                  <Loader2 className="h-3 w-3 mr-1 animate-spin" />
-                  Adding...
-                </>
-              ) : (
-                "Add Agent"
-              )}
+            <Button variant="ghost" size="sm" className="h-7 gap-1" onClick={() => { setShowAddForm(!showAddForm); setShowOrdForm(false); }} data-testid="add-agent-btn">
+              <Plus className="h-3.5 w-3.5" />
+              Add
             </Button>
           </div>
         </div>
-      )}
 
-      {/* Search */}
-      <div className="relative">
-        <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
-        <Input
-          placeholder="Search agents..."
-          data-testid="agent-search"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          className="h-8 pl-8 text-sm"
-        />
-      </div>
+        {/* ORD discovery form */}
+        {showOrdForm && (
+          <div className="rounded-lg border p-3 space-y-2 bg-muted/50">
+            <p className="text-xs text-muted-foreground">Enter an ORD endpoint to discover A2A agents.</p>
+            <Input
+              placeholder="https://example.com/.well-known/open-resource-discovery"
+              data-testid="ord-url-input"
+              value={ordUrl}
+              onChange={(e) => {
+                setOrdUrl(e.target.value);
+                if (discoverError) setDiscoverError("");
+                if (discoverMessage) setDiscoverMessage("");
+              }}
+              className="h-8 text-sm"
+              type="url"
+              inputMode="url"
+              autoComplete="url"
+              onKeyDown={(e) => e.key === "Enter" && handleDiscover()}
+            />
+            {discoverError && <p className="text-xs text-destructive">{discoverError}</p>}
+            {discoverMessage && <p className="text-xs text-muted-foreground">{discoverMessage}</p>}
+            <div className="flex justify-end">
+              <Button size="sm" onClick={handleDiscover} disabled={isDiscovering || !ordUrl.trim()} data-testid="discover-ord-submit">
+                {isDiscovering ? (
+                  <>
+                    <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+                    Discovering...
+                  </>
+                ) : (
+                  "Discover"
+                )}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* Add agent form */}
+        {showAddForm && (
+          <div className="rounded-lg border p-3 space-y-2 bg-muted/50">
+            <Input
+              placeholder="Enter agent URL..."
+              data-testid="add-agent-url"
+              value={newAgentUrl}
+              onChange={(e) => {
+                setNewAgentUrl(e.target.value);
+                if (addError) setAddError("");
+              }}
+              className="h-8 text-sm"
+              type="url"
+              inputMode="url"
+              autoComplete="url"
+              onKeyDown={(e) => e.key === "Enter" && handleAddAgent()}
+            />
+            {addError && <p className="text-xs text-destructive">{addError}</p>}
+            {!addError && newAgentUrl.trim() && !isValidNewAgentUrl && (
+              <p className="text-xs text-destructive">Please enter a valid absolute http:// or https:// URL.</p>
+            )}
+
+            {/* Auth for secured agent card endpoints */}
+            <Select value={addAuthType} onValueChange={(v) => setAddAuthType(v as AddAuthType)}>
+              <SelectTrigger className="h-8 text-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="none">No Authentication</SelectItem>
+                <SelectItem value="basic">Basic Auth</SelectItem>
+                <SelectItem value="bearer">Bearer Token</SelectItem>
+                <SelectItem value="apiKey">API Key</SelectItem>
+              </SelectContent>
+            </Select>
+
+            {addAuthType === "basic" && (
+              <div className="space-y-2">
+                <Input
+                  placeholder="Username"
+                  value={addUsername}
+                  onChange={(e) => setAddUsername(e.target.value)}
+                  className="h-8 text-sm"
+                  autoComplete="off"
+                />
+                <PasswordInput
+                  placeholder="Password"
+                  value={addPassword}
+                  onChange={(e) => setAddPassword(e.target.value)}
+                  className="h-8 text-sm"
+                  autoComplete="off"
+                />
+              </div>
+            )}
+
+            {addAuthType === "bearer" && (
+              <PasswordInput
+                placeholder="Bearer Token"
+                value={addToken}
+                onChange={(e) => setAddToken(e.target.value)}
+                className="h-8 text-sm"
+                autoComplete="off"
+              />
+            )}
+
+            {addAuthType === "apiKey" && (
+              <PasswordInput
+                placeholder="API Key"
+                value={addApiKey}
+                onChange={(e) => setAddApiKey(e.target.value)}
+                className="h-8 text-sm"
+                autoComplete="off"
+              />
+            )}
+
+            <div className="flex flex-wrap justify-end gap-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  setShowAddForm(false);
+                  setNewAgentUrl("");
+                  setAddError("");
+                }}
+                data-testid="add-agent-cancel">
+                Cancel
+              </Button>
+              <Button size="sm" onClick={handleAddAgent} disabled={isAdding || !isValidNewAgentUrl} data-testid="add-agent-submit">
+                {isAdding ? (
+                  <>
+                    <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+                    Adding...
+                  </>
+                ) : (
+                  "Add Agent"
+                )}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* Search */}
+        <div className="relative">
+          <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            placeholder="Search agents..."
+            data-testid="agent-search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="h-8 pl-8 text-sm"
+          />
+        </div>
       </div>
 
       {/* Custom agents section */}
@@ -340,15 +409,25 @@ export function PredefinedAgents() {
         </div>
       )}
 
+      {/* ORD agents section */}
+      {filteredOrd.length > 0 && (
+        <div className="space-y-2">
+          <p className="text-xs text-muted-foreground font-medium">ORD Agents</p>
+          {filteredOrd.map((agent) => renderAgentCard(agent, true))}
+        </div>
+      )}
+
       {/* Predefined agents section */}
       {filteredPredefined.length > 0 && (
         <div className="space-y-2">
-          {filteredCustom.length > 0 && <p className="text-xs text-muted-foreground font-medium">Examples</p>}
+          {(filteredCustom.length > 0 || filteredOrd.length > 0) && (
+            <p className="text-xs text-muted-foreground font-medium">Examples</p>
+          )}
           {filteredPredefined.map((agent) => renderAgentCard(agent, false))}
         </div>
       )}
 
-      {filteredCustom.length === 0 && filteredPredefined.length === 0 && (
+      {filteredCustom.length === 0 && filteredOrd.length === 0 && filteredPredefined.length === 0 && (
         <p className="text-xs text-muted-foreground text-center py-4">No agents found</p>
       )}
     </div>

--- a/src/lib/stores/__tests__/predefinedAgentsStore.test.ts
+++ b/src/lib/stores/__tests__/predefinedAgentsStore.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { usePredefinedAgentsStore } from "../predefinedAgentsStore";
+import type { PredefinedAgent } from "@lib/types/connection";
+
+vi.mock("@lib/utils/ord-discovery", () => ({
+  discoverAgentsFromOrd: vi.fn(),
+  isOrdUrl: vi.fn(),
+}));
+
+import { discoverAgentsFromOrd } from "@lib/utils/ord-discovery";
+const mockDiscover = vi.mocked(discoverAgentsFromOrd);
+
+function makeAgent(overrides: Partial<PredefinedAgent> = {}): PredefinedAgent {
+  return {
+    id: "ord-test:agent:v1",
+    name: "Test Agent",
+    description: "A test agent",
+    url: "http://localhost:3002/agent.json",
+    authType: "none",
+    tags: ["ORD"],
+    mocked: false,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  // Reset store state
+  usePredefinedAgentsStore.setState({ agents: [], selectedId: null });
+  // Clear localStorage
+  localStorage.clear();
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("loadFromOrd", () => {
+  it("adds discovered agents to the store", async () => {
+    const agent = makeAgent();
+    mockDiscover.mockResolvedValue([agent]);
+
+    await usePredefinedAgentsStore.getState().loadFromOrd("http://localhost:3002");
+
+    expect(usePredefinedAgentsStore.getState().agents).toHaveLength(1);
+    expect(usePredefinedAgentsStore.getState().agents[0].name).toBe("Test Agent");
+  });
+
+  it("returns the count of newly added agents", async () => {
+    mockDiscover.mockResolvedValue([makeAgent()]);
+
+    const added = await usePredefinedAgentsStore.getState().loadFromOrd("http://localhost:3002");
+    expect(added).toBe(1);
+  });
+
+  it("returns 0 when all discovered agents already exist (by url)", async () => {
+    const agent = makeAgent();
+    usePredefinedAgentsStore.setState({ agents: [agent], selectedId: null });
+    mockDiscover.mockResolvedValue([makeAgent({ id: "ord-different-id" })]);
+
+    const added = await usePredefinedAgentsStore.getState().loadFromOrd("http://localhost:3002");
+    expect(added).toBe(0);
+    expect(usePredefinedAgentsStore.getState().agents).toHaveLength(1);
+  });
+
+  it("deduplicates by url, not by id", async () => {
+    const existing = makeAgent({ id: "ord-existing", url: "http://localhost:3002/agent.json" });
+    usePredefinedAgentsStore.setState({ agents: [existing], selectedId: null });
+
+    // Different id, same url → should be skipped
+    const duplicate = makeAgent({ id: "ord-different", url: "http://localhost:3002/agent.json" });
+    mockDiscover.mockResolvedValue([duplicate]);
+
+    const added = await usePredefinedAgentsStore.getState().loadFromOrd("http://localhost:3002");
+    expect(added).toBe(0);
+  });
+
+  it("persists discovered agents to localStorage under a2a-ord-agents", async () => {
+    mockDiscover.mockResolvedValue([makeAgent()]);
+
+    await usePredefinedAgentsStore.getState().loadFromOrd("http://localhost:3002");
+
+    const stored = JSON.parse(localStorage.getItem("a2a-ord-agents") ?? "[]");
+    expect(stored).toHaveLength(1);
+    expect(stored[0].id).toBe("ord-test:agent:v1");
+  });
+
+  it("does not persist non-ord agents to a2a-ord-agents", async () => {
+    const customAgent = makeAgent({ id: "custom-123", url: "http://other.com/agent.json" });
+    usePredefinedAgentsStore.setState({ agents: [customAgent], selectedId: null });
+    mockDiscover.mockResolvedValue([makeAgent()]);
+
+    await usePredefinedAgentsStore.getState().loadFromOrd("http://localhost:3002");
+
+    const stored = JSON.parse(localStorage.getItem("a2a-ord-agents") ?? "[]");
+    expect(stored.every((a: PredefinedAgent) => a.id.startsWith("ord-"))).toBe(true);
+  });
+
+  it("propagates errors thrown by discoverAgentsFromOrd", async () => {
+    mockDiscover.mockRejectedValue(new Error("ORD config fetch failed: 404 Not Found"));
+
+    await expect(
+      usePredefinedAgentsStore.getState().loadFromOrd("http://bad-host.example.com"),
+    ).rejects.toThrow("ORD config fetch failed");
+  });
+
+  it("forwards auth headers to discoverAgentsFromOrd", async () => {
+    mockDiscover.mockResolvedValue([]);
+    const headers = { Authorization: "Bearer token123" };
+
+    await usePredefinedAgentsStore.getState().loadFromOrd("http://localhost:3002", headers);
+
+    expect(mockDiscover).toHaveBeenCalledWith("http://localhost:3002", headers);
+  });
+});
+
+describe("removeAgent for ORD agents", () => {
+  it("removes an ord- agent from the store", () => {
+    const agent = makeAgent({ id: "ord-ns:api:Solar:v1" });
+    usePredefinedAgentsStore.setState({ agents: [agent], selectedId: null });
+
+    usePredefinedAgentsStore.getState().removeAgent("ord-ns:api:Solar:v1");
+
+    expect(usePredefinedAgentsStore.getState().agents).toHaveLength(0);
+  });
+
+  it("updates a2a-ord-agents in localStorage after removal", () => {
+    const agent = makeAgent({ id: "ord-ns:api:Solar:v1" });
+    localStorage.setItem("a2a-ord-agents", JSON.stringify([agent]));
+    usePredefinedAgentsStore.setState({ agents: [agent], selectedId: null });
+
+    usePredefinedAgentsStore.getState().removeAgent("ord-ns:api:Solar:v1");
+
+    const stored = JSON.parse(localStorage.getItem("a2a-ord-agents") ?? "[]");
+    expect(stored).toHaveLength(0);
+  });
+
+  it("keeps other agents when removing an ord- agent", () => {
+    const ordAgent = makeAgent({ id: "ord-ns:api:Solar:v1", url: "http://localhost:3002/solar/agent.json" });
+    const customAgent = makeAgent({ id: "custom-123", url: "http://localhost:3002/custom/agent.json" });
+    usePredefinedAgentsStore.setState({ agents: [ordAgent, customAgent], selectedId: null });
+
+    usePredefinedAgentsStore.getState().removeAgent("ord-ns:api:Solar:v1");
+
+    expect(usePredefinedAgentsStore.getState().agents).toHaveLength(1);
+    expect(usePredefinedAgentsStore.getState().agents[0].id).toBe("custom-123");
+  });
+});
+
+describe("loadDefaults with persisted ORD agents", () => {
+  it("restores ord agents from localStorage on loadDefaults", async () => {
+    const stored = [makeAgent({ id: "ord-ns:api:Solar:v1" })];
+    localStorage.setItem("a2a-ord-agents", JSON.stringify(stored));
+    // Stub fetch so the predefined-agents.json load doesn't fail
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 404, json: vi.fn() }));
+
+    await usePredefinedAgentsStore.getState().loadDefaults();
+
+    const agents = usePredefinedAgentsStore.getState().agents;
+    expect(agents.some((a) => a.id === "ord-ns:api:Solar:v1")).toBe(true);
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/src/lib/stores/predefinedAgentsStore.ts
+++ b/src/lib/stores/predefinedAgentsStore.ts
@@ -1,12 +1,14 @@
 import { create } from "zustand";
 import type { PredefinedAgent } from "@lib/types/connection";
 import { getStoredJson, setStoredJson } from "@lib/utils/local-storage";
+import { discoverAgentsFromOrd } from "@lib/utils/ord-discovery";
 
 interface PredefinedAgentsState {
   agents: PredefinedAgent[];
   selectedId: string | null;
 
   loadDefaults: () => Promise<void>;
+  loadFromOrd: (url: string, headers?: Record<string, string>) => Promise<number>;
   addCustomAgent: (agent: PredefinedAgent) => void;
   removeAgent: (id: string) => void;
   select: (id: string) => void;
@@ -16,6 +18,9 @@ interface PredefinedAgentsState {
 // Predefined agents can be provided as a JSON array via VITE_PREDEFINED_AGENTS
 // env var. When set, the store uses it directly instead of fetching the JSON file.
 const ENV_AGENTS = import.meta.env.VITE_PREDEFINED_AGENTS ?? "";
+
+// Optional ORD endpoint to auto-discover agents on startup.
+const ENV_ORD_URL = import.meta.env.VITE_AGENTS_ORD_URL ?? "";
 
 // Get base URL for assets at runtime so standalone bundles work when hosted
 // on any path. Derives the URL from the script tag that loaded the bundle.
@@ -58,7 +63,41 @@ export const usePredefinedAgentsStore = create<PredefinedAgentsState>(
       }
 
       const custom: PredefinedAgent[] = getStoredJson("a2a-custom-agents", []);
-      set({ agents: [...custom, ...defaults] });
+      const ord: PredefinedAgent[] = getStoredJson("a2a-ord-agents", []);
+
+      const allAgents = [...custom, ...ord, ...defaults];
+      set({ agents: allAgents });
+
+      if (ENV_ORD_URL) {
+        try {
+          const discovered = await discoverAgentsFromOrd(ENV_ORD_URL);
+          set((state) => {
+            const existingUrls = new Set(state.agents.map((a) => a.url));
+            const fresh = discovered.filter((a) => !existingUrls.has(a.url));
+            if (fresh.length === 0) return state;
+            const newAgents = [...state.agents, ...fresh];
+            persistOrd(newAgents);
+            return { agents: newAgents };
+          });
+        } catch {
+          // Silent fail - ORD discovery is optional
+        }
+      }
+    },
+
+    loadFromOrd: async (url, headers) => {
+      const discovered = await discoverAgentsFromOrd(url, headers);
+      let added = 0;
+      set((state) => {
+        const existingUrls = new Set(state.agents.map((a) => a.url));
+        const fresh = discovered.filter((a) => !existingUrls.has(a.url));
+        added = fresh.length;
+        if (fresh.length === 0) return state;
+        const newAgents = [...state.agents, ...fresh];
+        persistOrd(newAgents);
+        return { agents: newAgents };
+      });
+      return added;
     },
 
     addCustomAgent: (agent) => {
@@ -77,6 +116,7 @@ export const usePredefinedAgentsStore = create<PredefinedAgentsState>(
       set((state) => {
         const newAgents = state.agents.filter((a) => a.id !== id);
         persistCustom(newAgents);
+        persistOrd(newAgents);
         return { agents: newAgents };
       });
     },
@@ -90,6 +130,11 @@ export const usePredefinedAgentsStore = create<PredefinedAgentsState>(
 function persistCustom(agents: PredefinedAgent[]) {
   const custom = agents.filter((a) => a.id.startsWith("custom-"));
   setStoredJson("a2a-custom-agents", custom);
+}
+
+function persistOrd(agents: PredefinedAgent[]) {
+  const ord = agents.filter((a) => a.id.startsWith("ord-"));
+  setStoredJson("a2a-ord-agents", ord);
 }
 
 // Selector for selected agent

--- a/src/lib/utils/__tests__/ord-discovery.test.ts
+++ b/src/lib/utils/__tests__/ord-discovery.test.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { isOrdUrl, discoverAgentsFromOrd } from "../ord-discovery";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// ─── Shared fixtures ──────────────────────────────────────────────────────────
+
+const BASE_URL = "http://localhost:3002";
+
+const ORD_CONFIG = {
+  openResourceDiscoveryV1: { documents: [{ url: "/ord/v1/documents/test" }] },
+};
+
+const SOLAR_CARD = {
+  name: "Solar System Explorer",
+  description: "Space weather agent",
+  url: `${BASE_URL}/solar`,
+  skills: [{ id: "s1", name: "Solar Weather", tags: ["space", "weather"] }],
+};
+
+const REPAIR_CARD = {
+  name: "Repair Technician",
+  description: "Hull repair agent",
+  url: `${BASE_URL}/repair`,
+  skills: [{ id: "r1", name: "Hull Repair", tags: ["repair", "hull"] }],
+};
+
+function makeDocument(overrides: Record<string, unknown> = {}) {
+  return {
+    agents: [
+      {
+        ordId: "ns:agent:Solar:v1",
+        title: "Solar Agent",
+        exposedApiResources: [{ ordId: "ns:apiResource:Solar:v1" }],
+      },
+    ],
+    apiResources: [
+      {
+        ordId: "ns:apiResource:Solar:v1",
+        title: "Solar API",
+        apiProtocol: "a2a",
+        resourceDefinitions: [{ type: "a2a-agent-card", url: "/solar/agent.json" }],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+// ─── isOrdUrl ─────────────────────────────────────────────────────────────────
+
+describe("isOrdUrl", () => {
+  it("returns true for a full well-known URL", () => {
+    expect(isOrdUrl(`${BASE_URL}/.well-known/open-resource-discovery`)).toBe(true);
+  });
+
+  it("returns true when well-known path appears anywhere in the URL", () => {
+    expect(isOrdUrl("https://example.com/.well-known/open-resource-discovery?v=1")).toBe(true);
+  });
+
+  it("returns false for a plain base URL", () => {
+    expect(isOrdUrl(BASE_URL)).toBe(false);
+  });
+
+  it("returns false for an agent card URL", () => {
+    expect(isOrdUrl(`${BASE_URL}/solar/agent.json`)).toBe(false);
+  });
+});
+
+// ─── discoverAgentsFromOrd ────────────────────────────────────────────────────
+
+describe("discoverAgentsFromOrd", () => {
+  it("returns empty array for empty input without fetching", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await discoverAgentsFromOrd("");
+    expect(result).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("appends well-known path when given a plain base URL", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 404, statusText: "Not Found", json: vi.fn() });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(discoverAgentsFromOrd(BASE_URL)).rejects.toThrow();
+    expect(fetchMock.mock.calls[0][0]).toBe(`${BASE_URL}/.well-known/open-resource-discovery`);
+  });
+
+  it("does not double-append well-known path when URL already contains it", async () => {
+    const ordUrl = `${BASE_URL}/.well-known/open-resource-discovery`;
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 404, statusText: "Not Found", json: vi.fn() });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(discoverAgentsFromOrd(ordUrl)).rejects.toThrow();
+    expect(fetchMock.mock.calls[0][0]).toBe(ordUrl);
+  });
+
+  it("strips trailing slash from base URL before appending well-known path", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 404, statusText: "Not Found", json: vi.fn() });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(discoverAgentsFromOrd(`${BASE_URL}/`)).rejects.toThrow();
+    expect(fetchMock.mock.calls[0][0]).toBe(`${BASE_URL}/.well-known/open-resource-discovery`);
+  });
+
+  it("throws when the ORD config fetch returns a non-OK response", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false, status: 404, statusText: "Not Found", json: vi.fn(),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(discoverAgentsFromOrd(BASE_URL)).rejects.toThrow("ORD config fetch failed: 404");
+  });
+
+  it("throws when the ORD config lists no documents", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true, status: 200, json: () => Promise.resolve({ openResourceDiscoveryV1: { documents: [] } }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(discoverAgentsFromOrd(BASE_URL)).rejects.toThrow("No ORD documents found");
+  });
+
+  it("discovers an agent using the agents[] + exposedApiResources pattern", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(ORD_CONFIG) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(makeDocument()) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(SOLAR_CARD) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const agents = await discoverAgentsFromOrd(BASE_URL);
+
+    expect(agents).toHaveLength(1);
+    expect(agents[0].name).toBe("Solar System Explorer");
+    expect(agents[0].description).toBe("Space weather agent");
+    expect(agents[0].id).toBe("ord-ns:apiResource:Solar:v1");
+    expect(agents[0].authType).toBe("none");
+    expect(agents[0].mocked).toBe(false);
+  });
+
+  it("stores the agent card URL (ending .json) as the agent url", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(ORD_CONFIG) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(makeDocument()) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(SOLAR_CARD) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const agents = await discoverAgentsFromOrd(BASE_URL);
+
+    expect(agents[0].url).toBe(`${BASE_URL}/solar/agent.json`);
+    expect(agents[0].url).toMatch(/\.json$/);
+  });
+
+  it("includes ORD tag and card skill tags", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(ORD_CONFIG) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(makeDocument()) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(SOLAR_CARD) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const agents = await discoverAgentsFromOrd(BASE_URL);
+
+    expect(agents[0].tags).toContain("ORD");
+    expect(agents[0].tags).toContain("space");
+    expect(agents[0].tags).toContain("weather");
+  });
+
+  it("falls back to scanning apiResources directly when no agents[] array is present", async () => {
+    const docWithoutAgents = {
+      apiResources: [
+        {
+          ordId: "ns:apiResource:Solar:v1",
+          title: "Solar API",
+          apiProtocol: "a2a",
+          resourceDefinitions: [{ type: "a2a-agent-card", url: "/solar/agent.json" }],
+        },
+      ],
+    };
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(ORD_CONFIG) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(docWithoutAgents) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(SOLAR_CARD) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const agents = await discoverAgentsFromOrd(BASE_URL);
+
+    expect(agents).toHaveLength(1);
+    expect(agents[0].name).toBe("Solar System Explorer");
+  });
+
+  it("recognises customType a2a:agent-card:v1 as an agent card definition", async () => {
+    const docWithCustomType = {
+      apiResources: [
+        {
+          ordId: "ns:apiResource:Solar:v1",
+          apiProtocol: "a2a",
+          resourceDefinitions: [{ customType: "a2a:agent-card:v1", url: "/solar/agent.json" }],
+        },
+      ],
+    };
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(ORD_CONFIG) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(docWithCustomType) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(SOLAR_CARD) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const agents = await discoverAgentsFromOrd(BASE_URL);
+    expect(agents).toHaveLength(1);
+  });
+
+  it("skips apiResources that have no agent card resource definition", async () => {
+    const doc = {
+      apiResources: [
+        {
+          ordId: "ns:apiResource:Solar:v1",
+          apiProtocol: "a2a",
+          resourceDefinitions: [{ type: "openapi", url: "/openapi.json" }],
+        },
+      ],
+    };
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(ORD_CONFIG) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(doc) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const agents = await discoverAgentsFromOrd(BASE_URL);
+    expect(agents).toHaveLength(0);
+  });
+
+  it("skips an agent when the card fetch returns non-OK", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(ORD_CONFIG) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(makeDocument()) })
+      .mockResolvedValueOnce({ ok: false, status: 404, json: vi.fn() });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const agents = await discoverAgentsFromOrd(BASE_URL);
+    expect(agents).toHaveLength(0);
+  });
+
+  it("deduplicates agents that resolve to the same card URL", async () => {
+    const docWithDuplicates = {
+      agents: [
+        { ordId: "ns:agent:A:v1", exposedApiResources: [{ ordId: "ns:api:A:v1" }] },
+        { ordId: "ns:agent:B:v1", exposedApiResources: [{ ordId: "ns:api:B:v1" }] },
+      ],
+      apiResources: [
+        { ordId: "ns:api:A:v1", apiProtocol: "a2a", resourceDefinitions: [{ type: "a2a-agent-card", url: "/solar/agent.json" }] },
+        { ordId: "ns:api:B:v1", apiProtocol: "a2a", resourceDefinitions: [{ type: "a2a-agent-card", url: "/solar/agent.json" }] },
+      ],
+    };
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(ORD_CONFIG) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(docWithDuplicates) })
+      .mockResolvedValue({ ok: true, json: () => Promise.resolve(SOLAR_CARD) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const agents = await discoverAgentsFromOrd(BASE_URL);
+    expect(agents).toHaveLength(1);
+  });
+
+  it("discovers multiple distinct agents from one document", async () => {
+    const docWithTwo = {
+      agents: [
+        { ordId: "ns:agent:Solar:v1", exposedApiResources: [{ ordId: "ns:api:Solar:v1" }] },
+        { ordId: "ns:agent:Repair:v1", exposedApiResources: [{ ordId: "ns:api:Repair:v1" }] },
+      ],
+      apiResources: [
+        { ordId: "ns:api:Solar:v1", apiProtocol: "a2a", resourceDefinitions: [{ type: "a2a-agent-card", url: "/solar/agent.json" }] },
+        { ordId: "ns:api:Repair:v1", apiProtocol: "a2a", resourceDefinitions: [{ type: "a2a-agent-card", url: "/repair/agent.json" }] },
+      ],
+    };
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(ORD_CONFIG) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(docWithTwo) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(SOLAR_CARD) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(REPAIR_CARD) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const agents = await discoverAgentsFromOrd(BASE_URL);
+    expect(agents).toHaveLength(2);
+    expect(agents.map((a) => a.name)).toContain("Solar System Explorer");
+    expect(agents.map((a) => a.name)).toContain("Repair Technician");
+  });
+
+  it("passes auth headers to all fetch calls", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(ORD_CONFIG) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(makeDocument()) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(SOLAR_CARD) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const headers = { Authorization: "Bearer token123" };
+    await discoverAgentsFromOrd(BASE_URL, headers);
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    fetchMock.mock.calls.forEach(([, opts]) => {
+      expect(opts).toEqual({ headers });
+    });
+  });
+});

--- a/src/lib/utils/ord-discovery.ts
+++ b/src/lib/utils/ord-discovery.ts
@@ -1,0 +1,171 @@
+import type { PredefinedAgent } from "@lib/types/connection";
+
+interface ORDConfig {
+  baseUrl?: string;
+  openResourceDiscoveryV1?: {
+    documents?: { url: string }[];
+  };
+}
+
+interface ORDApiResource {
+  ordId: string;
+  title?: string;
+  shortDescription?: string;
+  description?: string;
+  apiProtocol?: string;
+  resourceDefinitions?: Array<{
+    type?: string;
+    customType?: string;
+    url?: string;
+  }>;
+}
+
+interface ORDDocument {
+  agents?: Array<{
+    ordId: string;
+    title?: string;
+    shortDescription?: string;
+    exposedApiResources?: Array<{ ordId: string }>;
+  }>;
+  apiResources?: ORDApiResource[];
+}
+
+interface AgentCardJson {
+  name?: string;
+  description?: string;
+  skills?: Array<{ id: string; name: string; tags?: string[] }>;
+  url?: string;
+}
+
+export function isOrdUrl(url: string): boolean {
+  return url.includes(".well-known/open-resource-discovery");
+}
+
+/**
+ * Discovers A2A agents from an Open Resource Discovery endpoint.
+ *
+ * Accepts a base URL or a full `.well-known/open-resource-discovery` URL.
+ * Fetches the ORD config, then each document, resolves agent card URLs, and
+ * returns discovered A2A agents as PredefinedAgent entries with "ord-" id prefix.
+ */
+export async function discoverAgentsFromOrd(
+  inputUrl: string,
+  headers?: Record<string, string>,
+): Promise<PredefinedAgent[]> {
+  if (!inputUrl) return [];
+
+  let configUrl = inputUrl.replace(/\/$/, "");
+  if (!isOrdUrl(configUrl)) {
+    configUrl += "/.well-known/open-resource-discovery";
+  }
+
+  const fetchOpts: RequestInit | undefined = headers ? { headers } : undefined;
+
+  const configRes = await fetch(configUrl, fetchOpts);
+  if (!configRes.ok) {
+    throw new Error(`ORD config fetch failed: ${configRes.status} ${configRes.statusText}`);
+  }
+  const config: ORDConfig = await configRes.json();
+
+  const providerOrigin = new URL(configUrl).origin;
+  const baseUrl = (config.baseUrl || providerOrigin).replace(/\/$/, "");
+  const docUrls = config.openResourceDiscoveryV1?.documents?.map((d) => d.url) ?? [];
+
+  if (docUrls.length === 0) {
+    throw new Error("No ORD documents found at this endpoint");
+  }
+
+  const agents: PredefinedAgent[] = [];
+
+  for (const docPath of docUrls) {
+    const docUrl = docPath.startsWith("http") ? docPath : `${baseUrl}${docPath}`;
+    const docRes = await fetch(docUrl, fetchOpts);
+    if (!docRes.ok) continue;
+    const doc: ORDDocument = await docRes.json();
+
+    const docProviderOrigin = new URL(docUrl).origin;
+
+    const apiResourceMap = new Map(
+      (doc.apiResources ?? []).map((r) => [r.ordId, r]),
+    );
+
+    const ordAgents = doc.agents ?? [];
+    if (ordAgents.length > 0) {
+      for (const ordAgent of ordAgents) {
+        const exposedApiId = ordAgent.exposedApiResources?.[0]?.ordId;
+        const apiResource = exposedApiId ? apiResourceMap.get(exposedApiId) : undefined;
+        if (!apiResource) continue;
+
+        const agent = await buildAgentFromApiResource(
+          apiResource,
+          ordAgent.title || apiResource.title || "Unknown Agent",
+          ordAgent.shortDescription || apiResource.shortDescription || "",
+          docProviderOrigin,
+          fetchOpts,
+        );
+        if (agent) agents.push(agent);
+      }
+    } else {
+      // Fallback: scan apiResources directly for a2a protocol when no agents[] array present
+      for (const apiResource of doc.apiResources ?? []) {
+        if (apiResource.apiProtocol !== "a2a") continue;
+        const agent = await buildAgentFromApiResource(
+          apiResource,
+          apiResource.title || "Unknown Agent",
+          apiResource.shortDescription || apiResource.description || "",
+          docProviderOrigin,
+          fetchOpts,
+        );
+        if (agent) agents.push(agent);
+      }
+    }
+  }
+
+  const seen = new Set<string>();
+  return agents.filter((a) => {
+    if (seen.has(a.url)) return false;
+    seen.add(a.url);
+    return true;
+  });
+}
+
+async function buildAgentFromApiResource(
+  apiResource: ORDApiResource,
+  fallbackName: string,
+  fallbackDescription: string,
+  providerOrigin: string,
+  fetchOpts?: RequestInit,
+): Promise<PredefinedAgent | null> {
+  const cardDef = apiResource.resourceDefinitions?.find(
+    (rd) => rd.type === "a2a-agent-card" || rd.customType === "a2a:agent-card:v1",
+  );
+  if (!cardDef?.url) return null;
+
+  const cardUrl = cardDef.url.startsWith("http")
+    ? cardDef.url
+    : `${providerOrigin}${cardDef.url}`;
+
+  let card: AgentCardJson | null = null;
+  try {
+    const cardRes = await fetch(cardUrl, fetchOpts);
+    if (cardRes.ok) card = await cardRes.json();
+  } catch {
+    // silently skip unreachable agent cards
+  }
+
+  if (!card) return null;
+
+  const tags = [...new Set([...(card.skills?.flatMap((s) => s.tags ?? []) ?? []), "ORD"])];
+
+  // Store the agent card URL as `url` — the connection store fetches it directly
+  // (ends in .json) and sets messagingUrl from card.url for A2A messaging.
+  return {
+    id: `ord-${apiResource.ordId}`,
+    name: card.name || fallbackName,
+    description: card.description || fallbackDescription,
+    url: cardUrl,
+    authType: "none",
+    tags,
+    mocked: false,
+  };
+}

--- a/src/lib/utils/ord-discovery.ts
+++ b/src/lib/utils/ord-discovery.ts
@@ -1,34 +1,5 @@
 import type { PredefinedAgent } from "@lib/types/connection";
-
-interface ORDConfig {
-  baseUrl?: string;
-  openResourceDiscoveryV1?: {
-    documents?: { url: string }[];
-  };
-}
-
-interface ORDApiResource {
-  ordId: string;
-  title?: string;
-  shortDescription?: string;
-  description?: string;
-  apiProtocol?: string;
-  resourceDefinitions?: Array<{
-    type?: string;
-    customType?: string;
-    url?: string;
-  }>;
-}
-
-interface ORDDocument {
-  agents?: Array<{
-    ordId: string;
-    title?: string;
-    shortDescription?: string;
-    exposedApiResources?: Array<{ ordId: string }>;
-  }>;
-  apiResources?: ORDApiResource[];
-}
+import type { OrdConfiguration, ApiResource, OrdDocument } from "@open-resource-discovery/specification";
 
 interface AgentCardJson {
   name?: string;
@@ -65,7 +36,7 @@ export async function discoverAgentsFromOrd(
   if (!configRes.ok) {
     throw new Error(`ORD config fetch failed: ${configRes.status} ${configRes.statusText}`);
   }
-  const config: ORDConfig = await configRes.json();
+  const config: OrdConfiguration = await configRes.json();
 
   const providerOrigin = new URL(configUrl).origin;
   const baseUrl = (config.baseUrl || providerOrigin).replace(/\/$/, "");
@@ -81,7 +52,7 @@ export async function discoverAgentsFromOrd(
     const docUrl = docPath.startsWith("http") ? docPath : `${baseUrl}${docPath}`;
     const docRes = await fetch(docUrl, fetchOpts);
     if (!docRes.ok) continue;
-    const doc: ORDDocument = await docRes.json();
+    const doc: OrdDocument = await docRes.json();
 
     const docProviderOrigin = new URL(docUrl).origin;
 
@@ -130,7 +101,7 @@ export async function discoverAgentsFromOrd(
 }
 
 async function buildAgentFromApiResource(
-  apiResource: ORDApiResource,
+  apiResource: ApiResource,
   fallbackName: string,
   fallbackDescription: string,
   providerOrigin: string,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig(({ mode }) => {
     test: {
       include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
       environment: "jsdom",
+      pool: "forks",
     },
     plugins: [
       react(),


### PR DESCRIPTION
Adds ORD-based agent discovery to the predefined agents panel, mirroring the same feature in mcp-server-card-ui for MCP servers.

- New `discoverAgentsFromOrd` utility fetches the ORD well-known config, iterates documents, resolves agent card URLs, and returns PredefinedAgent entries (url = agent card .json path so the connection store fetches it directly and sets messagingUrl from card.url for A2A messaging)
- `predefinedAgentsStore` gains `loadFromOrd()`, persists discovered agents to localStorage under `a2a-ord-agents`, and respects the optional `VITE_AGENTS_ORD_URL` env var for auto-discovery on startup
- Settings panel gets a "Discover" button (Globe icon) that opens an ORD URL input; discovered agents appear in a dedicated "ORD Agents" section and are removable
- 26 unit tests across ord-discovery and predefinedAgentsStore
- Fix pre-existing `npm test` failure by adding `pool: "forks"` to vite.config.ts (vmThreads pool incompatible with @tailwindcss/vite)