### PR TITLE
feat: add terminal task state fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [unreleased]
 
+### Fixed
+
+- SSE streaming: non-terminal `task` envelopes (e.g. `submitted`) no longer close the stream prematurely. The chat store now keeps the stream open until a terminal state (`completed`, `failed`, `canceled`, `rejected`) is received, preventing blank or dropped responses from agents that send an initial task object before `artifact-update` / `status-update` events.
+
 ## [[0.4.4](https://github.com/open-resource-discovery/a2a-editor/releases/tag/v0.4.4)] - 2026-07-07
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-resource-discovery/a2a-editor",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-resource-discovery/a2a-editor",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@monaco-editor/react": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-resource-discovery/a2a-editor",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Analyze, validate, and interact with Agent-to-Agent (A2A) protocol agent cards. Connect to agents, inspect their capabilities, and test communication in real-time.",
   "license": "Apache-2.0",
   "author": "SAP SE",

--- a/src/lib/stores/chatStore.ts
+++ b/src/lib/stores/chatStore.ts
@@ -14,6 +14,7 @@ import {
   buildOutboundMessage,
   buildOutboundHeaders,
   buildOutboundConfiguration,
+  isTerminalTaskState,
 } from "@lib/utils/a2a-protocol";
 import { validateResponse, isFullyCompliant } from "@lib/utils/a2a-compliance";
 import { streamMessage } from "@lib/utils/a2a-stream";
@@ -343,7 +344,7 @@ export const useChatStore = create<ChatState>((set, get) => {
           updateMessage(agentMsgId, (msg) => {
             const updated: ChatMessage = { ...msg, status: status.state, taskId, contextId };
             if (status.message?.parts?.length) {
-              const isTerminal = status.state === "completed" || status.state === "failed";
+              const isTerminal = isTerminalTaskState(status.state);
               // Terminal status with parts = final full message; replace to avoid duplication
               // with parts already accumulated from artifact-update events
               updated.parts = isTerminal ? status.message.parts : [...msg.parts, ...status.message.parts];
@@ -364,8 +365,14 @@ export const useChatStore = create<ChatState>((set, get) => {
             } else {
               // Concatenate text from incoming chunk onto existing artifact
               const current = existingArtifacts[idx];
-              const currentText = current.parts.filter(isTextPart).map((p) => p.text).join("");
-              const incomingText = artifact.parts.filter(isTextPart).map((p) => p.text).join("");
+              const currentText = current.parts
+                .filter(isTextPart)
+                .map((p) => p.text)
+                .join("");
+              const incomingText = artifact.parts
+                .filter(isTextPart)
+                .map((p) => p.text)
+                .join("");
               const nonTextParts = [
                 ...current.parts.filter((p) => !isTextPart(p)),
                 ...artifact.parts.filter((p) => !isTextPart(p)),
@@ -394,6 +401,27 @@ export const useChatStore = create<ChatState>((set, get) => {
           const wrapped = { jsonrpc: "2.0" as const, result: task };
           const normalized = normalizeTaskResponse(wrapped);
           const result = processJsonRpcResponse(normalized);
+
+          // A `task` envelope can arrive mid-stream with a non-terminal state
+          // (e.g. the initial "submitted" task before any artifacts). Only treat
+          // it as the final response when its state is terminal — otherwise just
+          // capture ids/parts and keep the stream open for artifact-update and
+          // status-update events that carry the actual answer.
+          const taskState = (task.status as { state?: TaskState } | undefined)?.state;
+          if (!isTerminalTaskState(taskState)) {
+            updateMessage(agentMsgId, (msg) => ({
+              ...msg,
+              taskId: result?.taskId ?? msg.taskId,
+              contextId: result?.contextId ?? msg.contextId,
+              // Adopt parts/artifacts only if this envelope actually carried them.
+              parts: result?.parts ?? msg.parts,
+              artifacts: result?.artifacts ?? msg.artifacts,
+            }));
+            const nextTaskId = result?.taskId ?? (task.id as string | undefined);
+            if (nextTaskId) set({ currentTaskId: nextTaskId, contextId: result?.contextId ?? get().contextId });
+            return;
+          }
+
           const complianceDetails = validateResponse(normalized);
 
           updateMessage(agentMsgId, (msg) => ({

--- a/src/lib/stores/chatStore.ts
+++ b/src/lib/stores/chatStore.ts
@@ -413,7 +413,6 @@ export const useChatStore = create<ChatState>((set, get) => {
               ...msg,
               taskId: result?.taskId ?? msg.taskId,
               contextId: result?.contextId ?? msg.contextId,
-              // Adopt parts/artifacts only if this envelope actually carried them.
               parts: result?.parts ?? msg.parts,
               artifacts: result?.artifacts ?? msg.artifacts,
             }));

--- a/src/lib/utils/__tests__/a2a-protocol.test.ts
+++ b/src/lib/utils/__tests__/a2a-protocol.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { isTerminalTaskState, normalizeStreamEvent } from "../a2a-protocol";
+
+// ===================================================================
+// isTerminalTaskState
+// ===================================================================
+
+describe("isTerminalTaskState", () => {
+  it("returns true for terminal states", () => {
+    expect(isTerminalTaskState("completed")).toBe(true);
+    expect(isTerminalTaskState("failed")).toBe(true);
+    expect(isTerminalTaskState("canceled")).toBe(true);
+    expect(isTerminalTaskState("rejected")).toBe(true);
+  });
+
+  it("returns false for non-terminal states", () => {
+    expect(isTerminalTaskState("submitted")).toBe(false);
+    expect(isTerminalTaskState("working")).toBe(false);
+    expect(isTerminalTaskState("input-required")).toBe(false);
+    expect(isTerminalTaskState("auth-required")).toBe(false);
+    expect(isTerminalTaskState(undefined)).toBe(false);
+  });
+
+  it("normalizes v1.0 wire-format state names", () => {
+    expect(isTerminalTaskState("TASK_STATE_COMPLETED")).toBe(true);
+    expect(isTerminalTaskState("TASK_STATE_WORKING")).toBe(false);
+  });
+});
+
+// ===================================================================
+// normalizeStreamEvent — artifact-bearing v0.3 SSE sequence
+//
+// Regression: some agents stream the initial task envelope up front (state
+// "submitted"), deliver the answer via an artifact-update (per spec, "Results
+// SHOULD BE returned using Artifacts"), then close with a message-less terminal
+// status-update. The client must not finalize on the initial submitted task.
+// ===================================================================
+
+describe("normalizeStreamEvent — artifact answer flow", () => {
+  it("classifies the initial task envelope as a non-terminal task event", () => {
+    const event = {
+      jsonrpc: "2.0",
+      result: {
+        contextId: "c1",
+        id: "t1",
+        kind: "task",
+        status: { state: "submitted" },
+      },
+    };
+    const n = normalizeStreamEvent(event);
+    expect(n?.kind).toBe("task");
+    if (n?.kind === "task") {
+      expect((n.task.status as { state: string }).state).toBe("submitted");
+      expect(isTerminalTaskState((n.task.status as { state: string }).state)).toBe(false);
+    }
+  });
+
+  it("normalizes an artifact-update carrying the agent answer", () => {
+    const event = {
+      jsonrpc: "2.0",
+      result: {
+        artifact: {
+          artifactId: "a1",
+          name: "agent_result",
+          parts: [{ kind: "text", text: "Hello! I am here to help." }],
+        },
+        contextId: "c1",
+        kind: "artifact-update",
+        taskId: "t1",
+      },
+    };
+    const n = normalizeStreamEvent(event);
+    expect(n?.kind).toBe("artifact-update");
+    if (n?.kind === "artifact-update") {
+      expect(n.taskId).toBe("t1");
+      expect(n.artifact.parts).toHaveLength(1);
+      expect((n.artifact.parts[0] as { text: string }).text).toBe("Hello! I am here to help.");
+    }
+  });
+
+  it("normalizes a final status-update with no message", () => {
+    const event = {
+      jsonrpc: "2.0",
+      result: {
+        contextId: "c1",
+        final: true,
+        kind: "status-update",
+        status: { state: "completed" },
+        taskId: "t1",
+      },
+    };
+    const n = normalizeStreamEvent(event);
+    expect(n?.kind).toBe("status-update");
+    if (n?.kind === "status-update") {
+      expect(n.status.state).toBe("completed");
+      expect(n.status.message).toBeUndefined();
+    }
+  });
+});

--- a/src/lib/utils/a2a-protocol.ts
+++ b/src/lib/utils/a2a-protocol.ts
@@ -91,9 +91,7 @@ export function normalizeAgentCard(raw: unknown): AgentCard {
 
   // Normalize v1.0 securityRequirements to v0.3 security format
   if (Array.isArray(card.securityRequirements) && !card.security) {
-    card.security = (card.securityRequirements as Array<Record<string, unknown>>).map(
-      normalizeSecurityRequirement,
-    );
+    card.security = (card.securityRequirements as Array<Record<string, unknown>>).map(normalizeSecurityRequirement);
   }
 
   return card as unknown as AgentCard;
@@ -113,7 +111,12 @@ function normalizeSecurityScheme(scheme: Record<string, unknown>): Record<string
   }
   if (scheme.oauth2SecurityScheme && typeof scheme.oauth2SecurityScheme === "object") {
     const inner = scheme.oauth2SecurityScheme as Record<string, unknown>;
-    return { type: "oauth2", flows: inner.flows, oauth2MetadataUrl: inner.oauth2MetadataUrl, description: inner.description };
+    return {
+      type: "oauth2",
+      flows: inner.flows,
+      oauth2MetadataUrl: inner.oauth2MetadataUrl,
+      description: inner.description,
+    };
   }
   if (scheme.apiKeySecurityScheme && typeof scheme.apiKeySecurityScheme === "object") {
     const inner = scheme.apiKeySecurityScheme as Record<string, unknown>;
@@ -259,7 +262,12 @@ export function normalizeTaskResponse(data: unknown): unknown {
   if ("task" in result && typeof result.task === "object" && !("status" in result) && !("id" in result)) {
     result = result.task as Record<string, unknown>;
     response.result = result;
-  } else if ("message" in result && typeof result.message === "object" && !("status" in result) && !("role" in result)) {
+  } else if (
+    "message" in result &&
+    typeof result.message === "object" &&
+    !("status" in result) &&
+    !("role" in result)
+  ) {
     // v1.0 Message response — normalize the message and wrap as a minimal task
     const msg = result.message as Record<string, unknown>;
     normalizeMessageInPlace(msg);
@@ -607,3 +615,17 @@ export const ALL_VALID_STATES = new Set([
   "TASK_STATE_AUTH_REQUIRED",
   "TASK_STATE_UNSPECIFIED",
 ]);
+
+/**
+ * Terminal (internal, human-readable) task states — the task has finished and
+ * will not produce further updates. Used to decide when a streamed message is
+ * done and when a `task` envelope should be treated as the final response.
+ * Non-terminal states (submitted, working, input-required, auth-required) mean
+ * more events may still arrive.
+ */
+export const TERMINAL_TASK_STATES = new Set<TaskState>(["completed", "failed", "canceled", "rejected"]);
+
+/** Whether a task state is terminal (no further updates expected). */
+export function isTerminalTaskState(state: TaskState | string | undefined): boolean {
+  return typeof state === "string" && TERMINAL_TASK_STATES.has(normalizeTaskState(state));
+}


### PR DESCRIPTION
Agents that follow the A2A SSE format may send an initial `task` envelope with state `submitted` (or other non-terminal states) before streaming the actual answer via `artifact-update` / `status-update` events. The chat store was treating any `task` envelope as the final response, causing the stream to be closed early and the answer to be lost.