### PR TITLE
chore(deps): consolidate Renovate dependency updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "sonner": "2.0.8",
         "tailwind-merge": "3.6.0",
         "uuid": "14.0.2",
-        "zod": "4.5.2",
+        "zod": "4.5.4",
         "zustand": "5.0.15"
       },
       "devDependencies": {
@@ -56,8 +56,8 @@
         "prettier": "3.9.6",
         "react": "19.2.8",
         "react-dom": "19.2.8",
-        "react-router-dom": "7.18.2",
-        "satori": "0.33.3",
+        "react-router-dom": "7.18.3",
+        "satori": "0.33.4",
         "tailwindcss": "4.3.3",
         "tsc-alias": "1.9.2",
         "typescript": "6.0.3",
@@ -3855,9 +3855,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.13",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
-      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
+      "integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "peer": true,
       "optionalDependencies": {
@@ -6410,9 +6410,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
-      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.3.tgz",
+      "integrity": "sha512-gyXgtdr5uACJ5b1Q4udzjVV+tb/rlHIMJKuJ0e89R4Kzgz47z/rgP0dIKxktqIEUhDHluGTPJJH/wRha7CyqsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6433,13 +6433,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
-      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.3.tgz",
+      "integrity": "sha512-ytVbyBBM7vMfRCam25r0WMhSVSom909A8p+8m0/f1w853dz/xfFu6etAT2SEbVoSnI+ZoPRDqIsQXVT89gp7kg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.18.2"
+        "react-router": "7.18.3"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -6626,9 +6626,9 @@
       }
     },
     "node_modules/satori": {
-      "version": "0.33.3",
-      "resolved": "https://registry.npmjs.org/satori/-/satori-0.33.3.tgz",
-      "integrity": "sha512-9dOJkLzIsBqEfaJZxn/u7dBtUcm6+rcNQ6qEWo600Ar50Cudq9mTzyW6fCiasbdV1N+dKuUAWGo+KzGOdS7+qg==",
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/satori/-/satori-0.33.4.tgz",
+      "integrity": "sha512-dCnaW6D/tkCJxG5UvpZPWnnvfTdGTVVSAq1tzH6xC5MeOhAeeswRcSq5zT7C6lRCdTGow9PRGus7PCzdp5JJYw==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -7963,9 +7963,9 @@
       "license": "MIT"
     },
     "node_modules/zod": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.2.tgz",
-      "integrity": "sha512-XkYXCol10+ba/6F/cueWV+TezUeOqXW0hdeJt5CdXjTYeAgAQg5N03RQdJ80mhfFE72+pblvYMW4wy2Qp4Qbrg==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -140,11 +140,11 @@
     "sonner": "2.0.8",
     "tailwind-merge": "3.6.0",
     "uuid": "14.0.2",
-    "zod": "4.5.2",
+    "zod": "4.5.4",
     "zustand": "5.0.15"
   },
   "overrides": {
-    "dompurify": ">=3.4.12"
+    "dompurify": "3.4.14"
   },
   "lint-staged": {
     "*.{ts,tsx}": [
@@ -177,8 +177,8 @@
     "prettier": "3.9.6",
     "react": "19.2.8",
     "react-dom": "19.2.8",
-    "react-router-dom": "7.18.2",
-    "satori": "0.33.3",
+    "react-router-dom": "7.18.3",
+    "satori": "0.33.4",
     "tailwindcss": "4.3.3",
     "tsc-alias": "1.9.2",
     "typescript": "6.0.3",

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -17009,9 +17009,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.1.0.tgz",
-      "integrity": "sha512-RNEqWOyhhUQYN9V1GfHwu9AR/g+NTciH6Z5u3/no6X3/w+04J2lVDL+svFQVXgXrEGBMG2puMVN3gq2SNGuTGw==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.1.1.tgz",
+      "integrity": "sha512-k3CMsaIvvdSwm8oLB4MXSl0wH2/cwlH7xGcnRd2DaeRmBkbzYmyT8j0tsX60DwD1eRwHTpNpH8ljKu9oUT1MeQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=20.0.0"

--- a/website/package.json
+++ b/website/package.json
@@ -26,7 +26,7 @@
     "react-dom": "18.3.1"
   },
   "overrides": {
-    "serialize-javascript": "^7.0.3",
+    "serialize-javascript": "^7.1.0",
     "webpack-dev-server": ">=6.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Consolidates the 2 open Renovate PRs into a single update. Base branch: `deps/all-patches` (2026-08-29) — superset of `deps/pin-dependencies` (every package at an equal or higher version, plus additional updates).

## Security fixes included

| Package | Change | Advisory | Severity |
|---|---|---|---|
| `dompurify` (override) | `>=3.4.12` → `3.4.14` | [3.4.14 release](https://github.com/cure53/DOMPurify/releases/tag/3.4.14) — fixes possible sanitizer bypasses when risky tags are allow-listed | Moderate |
| `serialize-javascript` | `^7.0.3` → `^7.1.1` | [v7.1.1](https://github.com/yahoo/serialize-javascript/releases/tag/v7.1.1) — fixes XSS bypass via split `</script` payload | Moderate |

## Other changes
- `react-router-dom` 7.18.2 → 7.18.3
- `satori` 0.33.3 → 0.33.4
- `zod` 4.4.3 → 4.5.4
- `lucide-react` 1.33.0 → 1.37.0
- `uuid` → 14.0.2
- Dev deps bumped: `@types/react-dom`, `@vitejs/plugin-react`, `eslint`, `eslint-plugin-react-refresh`, `lint-staged`, `typescript-eslint`
- `dompurify` override pinned to an exact version (from the range in #105)

> `webpack-dev-server` (in #105) is not present in this project's lockfile as a pinnable override — no impact here.

Closes #106
Closes #105